### PR TITLE
sepolicy: Allow perf HAL to set freq props

### DIFF
--- a/vendor/common/hal_perf_default.te
+++ b/vendor/common/hal_perf_default.te
@@ -41,7 +41,6 @@ allow hal_perf_client hal_perf_hwservice:hwservice_manager find;
 allow hal_perf cgroup:file r_file_perms;
 allow hal_perf_default proc:file rw_file_perms;
 allow hal_perf device_latency:chr_file rw_file_perms;
-allow hal_perf freq_prop:file r_file_perms;
 allow hal_perf vendor_mpctl_prop:file r_file_perms;
 allow hal_perf_default mpctl_data_file:dir rw_dir_perms;
 allow hal_perf_default mpctl_data_file:file create_file_perms;
@@ -49,6 +48,9 @@ allow hal_perf_default lm_data_file:dir rw_dir_perms;
 allow hal_perf_default lm_data_file:file create_file_perms;
 allow hal_perf_default sysfs_lib:file w_file_perms;
 r_dir_file(hal_perf_default, appdomain);
+
+# Allow perf HAL to set freq props
+set_prop(hal_perf_default, freq_prop)
 
 allow hal_perf {
     sysfs_devices_system_cpu


### PR DESCRIPTION
 * Addresses the following errors caught in a log:

    E ANDR-PERF-TARGET-INIT: Inside InitializeTarget
    W vendor.qti.hard: type=1400 audit(0.0:12): avc: denied { write } for name="property_service" dev="tmpfs" ino=14909 scontext=u:r:hal_perf_default:s0 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0
    W vendor.qti.hard: type=1400 audit(0.0:13): avc: denied { write } for name="property_service" dev="tmpfs" ino=14909 scontext=u:r:hal_perf_default:s0 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0
    W libc    : Unable to set property "ro.min_freq_0" to "384000": connection failed; errno=13 (Permission denied)
    W libc    : Unable to set property "ro.min_freq_4" to "384000": connection failed; errno=13 (Permission denied)

Change-Id: I6de28c23fdb816faad0eaf45e8f4d793865d6eea